### PR TITLE
김지홍 : BOJ 1991 S1 트리순회

### DIFF
--- a/kjh95044/src/week3/BOJ_1991_S1_트리순회/BOJ_1991_S1_트리순회.java
+++ b/kjh95044/src/week3/BOJ_1991_S1_트리순회/BOJ_1991_S1_트리순회.java
@@ -1,0 +1,66 @@
+package week3.BOJ_1991_S1_트리순회;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+
+public class BOJ_1991_S1_트리순회 {
+	
+	static StringBuilder sb = new StringBuilder();
+	static HashMap<Character, Character[]>map = new HashMap<>();
+	
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		
+		for (int i = 0; i < T; i++) {
+			String[] split = br.readLine().split(" ");
+			char node = split[0].charAt(0);
+			map.put(node, new Character[] {split[1].charAt(0), split[2].charAt(0)});
+		}
+		
+		dfsPreorder('A');
+		sb.append("\n");
+		dfsInorder('A');
+		sb.append("\n");
+		dfsPostOrder('A');
+		sb.append("\n");
+		System.out.println(sb);
+	}
+
+
+	// 전위 순회
+	private static void dfsPreorder(char node) {
+		sb.append(node);
+		for(char child : map.get(node)) {
+			if(child == '.') {
+				continue;
+			}
+			dfsPreorder(child);
+		}
+	}
+	
+	// 중위 순회
+	private static void dfsInorder(char node) {
+		if(map.get(node)[0] != '.') {
+			dfsInorder(map.get(node)[0]);
+		}
+		sb.append(node);
+		if(map.get(node)[1] != '.') {
+			dfsInorder(map.get(node)[1]);
+		}	
+	}
+	
+	//후위 순회
+	private static void dfsPostOrder(char node) {
+		for(char child : map.get(node)) {
+			if(child == '.') {
+				continue;
+			}
+			dfsPostOrder(child);
+		}
+		sb.append(node);
+	}
+}

--- a/kjh95044/src/week3/BOJ_1991_S1_트리순회/readme.md
+++ b/kjh95044/src/week3/BOJ_1991_S1_트리순회/readme.md
@@ -1,0 +1,39 @@
+# [Silver I] 트리 순회 - 1991 
+
+[문제 링크](https://www.acmicpc.net/problem/1991) 
+
+### 성능 요약
+
+메모리: 14100 KB, 시간: 120 ms
+
+### 분류
+
+재귀(recursion), 트리(trees)
+
+### 문제 설명
+
+<p>이진 트리를 입력받아 전위 순회(preorder traversal), 중위 순회(inorder traversal), 후위 순회(postorder traversal)한 결과를 출력하는 프로그램을 작성하시오.</p>
+
+<p style="text-align: center;"><img alt="" src="https://www.acmicpc.net/JudgeOnline/upload/201007/trtr.png" style="height:220px; width:265px"></p>
+
+<p>예를 들어 위와 같은 이진 트리가 입력되면,</p>
+
+<ul>
+	<li>전위 순회한 결과 : ABDCEFG // (루트) (왼쪽 자식) (오른쪽 자식)</li>
+	<li>중위 순회한 결과 : DBAECFG // (왼쪽 자식) (루트) (오른쪽 자식)</li>
+	<li>후위 순회한 결과 : DBEGFCA // (왼쪽 자식) (오른쪽 자식) (루트)</li>
+</ul>
+
+<p>가 된다.</p>
+
+### 입력 
+
+ <p>첫째 줄에는 이진 트리의 노드의 개수 N(1 ≤ N ≤ 26)이 주어진다. 둘째 줄부터 N개의 줄에 걸쳐 각 노드와 그의 왼쪽 자식 노드, 오른쪽 자식 노드가 주어진다. 노드의 이름은 A부터 차례대로 알파벳 대문자로 매겨지며, 항상 A가 루트 노드가 된다. 자식 노드가 없는 경우에는 .으로 표현한다.</p>
+
+### 출력 
+
+ <p>첫째 줄에 전위 순회, 둘째 줄에 중위 순회, 셋째 줄에 후위 순회한 결과를 출력한다. 각 줄에 N개의 알파벳을 공백 없이 출력하면 된다.</p>
+
+### 🐟풀이
+
+hash map에 character 배열 형태로 값을 넣어주고 전위, 중위, 후위에 맞춰서 수행했다.


### PR DESCRIPTION
# [Silver I] 트리 순회 - 1991 

[문제 링크](https://www.acmicpc.net/problem/1991) 

### 성능 요약

메모리: 14100 KB, 시간: 120 ms

### 분류

재귀(recursion), 트리(trees)

### 문제 설명

<p>이진 트리를 입력받아 전위 순회(preorder traversal), 중위 순회(inorder traversal), 후위 순회(postorder traversal)한 결과를 출력하는 프로그램을 작성하시오.</p>

<p style="text-align: center;"><img alt="" src="https://www.acmicpc.net/JudgeOnline/upload/201007/trtr.png" style="height:220px; width:265px"></p>

<p>예를 들어 위와 같은 이진 트리가 입력되면,</p>

<ul>
	<li>전위 순회한 결과 : ABDCEFG // (루트) (왼쪽 자식) (오른쪽 자식)</li>
	<li>중위 순회한 결과 : DBAECFG // (왼쪽 자식) (루트) (오른쪽 자식)</li>
	<li>후위 순회한 결과 : DBEGFCA // (왼쪽 자식) (오른쪽 자식) (루트)</li>
</ul>

<p>가 된다.</p>

### 입력 

 <p>첫째 줄에는 이진 트리의 노드의 개수 N(1 ≤ N ≤ 26)이 주어진다. 둘째 줄부터 N개의 줄에 걸쳐 각 노드와 그의 왼쪽 자식 노드, 오른쪽 자식 노드가 주어진다. 노드의 이름은 A부터 차례대로 알파벳 대문자로 매겨지며, 항상 A가 루트 노드가 된다. 자식 노드가 없는 경우에는 .으로 표현한다.</p>

### 출력 

 <p>첫째 줄에 전위 순회, 둘째 줄에 중위 순회, 셋째 줄에 후위 순회한 결과를 출력한다. 각 줄에 N개의 알파벳을 공백 없이 출력하면 된다.</p>

### 🐟풀이

hash map에 character 배열 형태로 값을 넣어주고 전위, 중위, 후위에 맞춰서 수행했다.