### PR TITLE
강소현 : BOJ 1939 G3 중량제한

### DIFF
--- a/sohyeon/src/week23/BOJ_1939_G3_중량제한/Main.java
+++ b/sohyeon/src/week23/BOJ_1939_G3_중량제한/Main.java
@@ -1,0 +1,89 @@
+package week23.BOJ_1939_G3_중량제한;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main{
+	
+	static class Node implements Comparable<Node>{
+		int vertex;
+		int cost;
+		Node link;
+		int minw;
+		public Node(int vertex, int cost, Node link) {
+			super();
+			this.vertex = vertex;
+			this.cost = cost;
+			this.link = link;
+		}
+		public Node(int vertex, int minw) {
+			super();
+			this.vertex = vertex;
+			this.minw = minw;
+		}
+		@Override
+		public int compareTo(Node o) {			
+			return o.minw-this.minw;
+		}			
+	}
+	
+	static int N,M;
+	static Node[] adjList;
+
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(in.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+	
+		adjList = new Node[N+1];
+		int a,b,c;
+		for (int i=0; i<M; i++) {
+			st = new StringTokenizer(in.readLine());
+			a = Integer.parseInt(st.nextToken());
+			b = Integer.parseInt(st.nextToken());
+			c = Integer.parseInt(st.nextToken());
+			adjList[a] = new Node(b,c,adjList[a]);
+			adjList[b] = new Node(a,c,adjList[b]);
+		}	
+		
+		st = new StringTokenizer(in.readLine());
+		int start = Integer.parseInt(st.nextToken());
+		int end = Integer.parseInt(st.nextToken());
+		
+		PriorityQueue<Node> queue = new PriorityQueue<>();
+		for (Node n=adjList[start]; n!=null; n=n.link) {
+			queue.offer(new Node(n.vertex, n.cost));
+		}
+		boolean[] visited = new boolean[N+1];
+		Node poll;
+		int result = 0;
+		while(!queue.isEmpty()) {
+			
+			poll = queue.poll();
+			
+			if (visited[poll.vertex]) continue;
+			visited[poll.vertex] = true;
+			
+			if (poll.minw<result) continue;
+			if (poll.vertex==end) {
+				result = poll.minw;
+				continue;
+			}
+			
+			for (Node n=adjList[poll.vertex]; n!=null; n=n.link) {
+				queue.offer(new Node(n.vertex, Math.min(poll.minw, n.cost)));
+			}
+			
+		}
+		
+		System.out.println(result);
+		
+	}
+	
+}
+

--- a/sohyeon/src/week23/BOJ_1939_G3_중량제한/README.md
+++ b/sohyeon/src/week23/BOJ_1939_G3_중량제한/README.md
@@ -1,0 +1,13 @@
+# Solution
+
+**bfs**
+- 우선순위 큐에 시작 섬과 인접한 섬과 그 섬까지의 비용(minw)을 Node 객체에 담아 넣는다. minw는 우선순의 큐 안에서 내림차 순으로 정렬하기 위한 기준이된다.
+- 큐에서 node를 poll 했을 때 minw가 옮길 수 있는 최대 충량인 result 보다 작으면 continue,
+아니면 인접한 노드까지의 비용과 minw중 더 작은 값을 minw로하는 새로운 node를 큐에 offer. poll한 node의 vertex가 도착 섬(end)이면 poll.minw와 result를 비교에서 더 큰 값으로 result 갱신 
+- 큐가 비면 result 반환 
+
+</br>
+
+|메모리|시간|
+|---|---|
+|59708 KB|616 ms|


### PR DESCRIPTION
# Solution

**bfs**
- 우선순위 큐에 시작 섬과 인접한 섬과 그 섬까지의 비용(minw)을 Node 객체에 담아 넣는다. minw는 우선순의 큐 안에서 내림차 순으로 정렬하기 위한 기준이된다.
- 큐에서 node를 poll 했을 때 minw가 옮길 수 있는 최대 충량인 result 보다 작으면 continue,
아니면 인접한 노드까지의 비용과 minw중 더 작은 값을 minw로하는 새로운 node를 큐에 offer. poll한 node의 vertex가 도착 섬(end)이면 poll.minw와 result를 비교에서 더 큰 값으로 result 갱신 
- 큐가 비면 result 반환 

</br>

|메모리|시간|
|---|---|
|59708 KB|616 ms|